### PR TITLE
update charter test suite section

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -163,16 +163,10 @@
     <h3 id="test-suites">
       Test Suites and Other Software
     </h3>
-    <p class="remove">
-      {TBD: State whether test suites or any other software will be created for
-      any Specifications and list the relevant licenses. For information about
-      contributions to W3C test suites, please see <a href=
-      "http://testthewebforward.org/">Test the Web Forward</a>, and take note
-      of the <a href="http://www.w3.org/2004/10/27-testcases">W3C's test suite
-      contribution policy</a> and <a href=
-      "http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html">licenses
-      for W3C test suites</a>. If there are no plans to create a test suite or
-      other software, please state that.}
+    <p>
+      The group MAY produce test suites to support the Specifications.  Please see 
+      the <a href="http://testthewebforward.org/">LICENSE</a> file for contribution 
+      licensing information.
     </p>
     <h2 id="liaisons">
       Dependencies or Liaisons


### PR DESCRIPTION
remove boilerplate language and say the group may produce test suites and refer to the LICENSE file for contribution licensing information. #53 #54