### PR TITLE
charter test code - got URL wrong

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -165,7 +165,7 @@
     </h3>
     <p>
       The group MAY produce test suites to support the Specifications.  Please see 
-      the <a href="http://testthewebforward.org/">LICENSE</a> file for contribution 
+      the <a href="https://github.com/w3c/webvr/blob/gh-pages/LICENSE.md">LICENSE</a> file for contribution 
       licensing information.
     </p>
     <h2 id="liaisons">


### PR DESCRIPTION
#55 - sorry, I got the URL wrong with a cut and paste error. It was meant to link to this WGs LICENSE file. [https://github.com/w3c/webvr/blob/gh-pages/LICENSE.md](https://github.com/w3c/webvr/blob/gh-pages/LICENSE.md)