### PR TITLE
Make VRLayer.leftBound and VRLayer.rightBounds non-nullable (Fix #95)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -265,8 +265,8 @@ typedef (HTMLCanvasElement or
 dictionary VRLayer {
   VRSource? source = null;
 
-  sequence&lt;float&gt;? leftBounds = [ ];
-  sequence&lt;float&gt;? rightBounds = [ ];
+  sequence&lt;float&gt; leftBounds = [ ];
+  sequence&lt;float&gt; rightBounds = [ ];
 };
 </pre>
 


### PR DESCRIPTION
Rather than assigning null values, we should use the default, empty
array.