### PR TITLE
Change VRDisplayEvent#reason to be non-nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -642,7 +642,7 @@ The {{VRDisplay}} has detected that the user has taken it off.
 [Constructor(DOMString type, VRDisplayEventInit eventInitDict)]
 interface VRDisplayEvent : Event {
   readonly attribute VRDisplay display;
-  readonly attribute VRDisplayEventReason? reason;
+  readonly attribute VRDisplayEventReason reason;
 };
 
 dictionary VRDisplayEventInit : EventInit {


### PR DESCRIPTION
This will match the behaviour of display and it makes sense for it to be non-nullable since it is already non-nullable in its EventInit dictionary.