### PR TITLE
Make VRView.eye non-nullable

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -618,7 +618,7 @@ enum VREye {
 };
 
 interface VRView {
-  readonly attribute VREye? eye;
+  readonly attribute VREye eye;
   readonly attribute Float32Array projectionMatrix;
 
   VRViewport? getViewport(VRLayer layer);


### PR DESCRIPTION
This struck me as a bit odd when I saw it, so I asked around and it
seems like only one other web spec has a nullable enum (WebPayments)
and it’s not clear if it’s intentional or necessary that that was the
case. As such I think we should stick with the majority and make this
non-nullable.

That of course leaves a question of “What do we return when there is no
intrinsically associated eye?” My vote would be: Just return “left” and
be done with it. This attribute will probably only ever be used when
rendering content with pre-rendered stereo, and such content will
always need to pick an eye to present regardless of display mechanism.
(Realtime content generally won’t care about which eye is being
rendered, and will just use the prescribed view matrices.) By making
the API choose a reasonable default we make the cases where it’s needed
that much easier for developers.

Happy to hear if there’s scenarios I haven’t considered that require
more nuance. If there is I’m in favor of adding a “none”, “unknown”, or
<empty string> entry to the enum rather than leave it nullable.