### PR TITLE
Added `VRDisplay.isTransparent` attribute and related example.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -483,6 +483,31 @@ vrSession.addEventListener('resetpose', vrSessionEvent => {
 });
 ```
 
+### Handling Transparent Displays
+
+The majority of current VR devices are opaque and do not enable the user to see their surrounding environment while using it. However some devices, like Microsoft's HoloLens, utilize transparent displays in the service of AR features. While the initial version of the WebVR API does not attempt to provide access to AR-centric features it does communicate whether or no the device display is see-through with the `isTransparent` attribute.
+
+WebVR content may want to refrain from drawing a background over the full frame in cases where the display is transparent, to allow the virtual content to appear as if it's floating in the real environment. (Note that this version of the WebVR API provides no mechanism for aligning or occluding content againts the environment.) To do so rendering of virtual backgrounds should be skipped when the display indicates it is transparent.
+
+```js
+function onDrawFrame(vrFrame) {
+  let pose = vrFrame.getDevicePose(vrFrameOfRef);
+  gl.bindFramebuffer(vrSession.baseLayer.framebuffer);
+
+  for (let view in vrFrame.views) {
+    let viewport = view.getViewport(vrSession.baseLayer);
+    gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
+    if (!vrDisplay.isTransparent) {
+      drawBackgroundContent(view, pose);
+    }
+    drawPrimaryContent(view, pose);
+  }
+
+  // Request the next VR callback
+  vrSession.requestFrame(onDrawFrame);
+}
+```
+
 ### Page navigation
 
 WebVR applications can, like any web page, link to other pages. In the context of a VR scene this is handled by setting `window.location` to the desired URL when the user performs some action. If the page being linked to is not VR-capable the user will either have to remove the VR device to view it (which the UA should explicitly instruct them to do) or the page could be shown as a 2D page in a VR browser.
@@ -561,6 +586,7 @@ typedef (WebGLRenderingContext or
 interface VRDevice : EventTarget {
   readonly attribute DOMString deviceName;
   readonly attribute boolean isExternal;
+  readonly attribute boolean isTransparent;
 
   attribute VRSession? activeSession;
 

--- a/explainer.md
+++ b/explainer.md
@@ -485,7 +485,7 @@ vrSession.addEventListener('resetpose', vrSessionEvent => {
 
 ### Handling Transparent Displays
 
-The majority of current VR devices are opaque and do not enable the user to see their surrounding environment while using it. However some devices, like Microsoft's HoloLens, utilize transparent displays in the service of AR features. While the initial version of the WebVR API does not attempt to provide access to AR-centric features it does communicate whether or no the device display is see-through with the `isTransparent` attribute.
+The majority of current VR devices are opaque and do not enable the user to see their surrounding environment while using it. However some devices, like Microsoft's HoloLens, utilize transparent displays in the service of AR features. While the initial version of the WebVR API does not attempt to provide access to AR-centric features it does communicate whether or no the device display is see-through with the session's `isTransparent` attribute.
 
 WebVR content may want to refrain from drawing a background over the full frame in cases where the display is transparent, to allow the virtual content to appear as if it's floating in the real environment. (Note that this version of the WebVR API provides no mechanism for aligning or occluding content againts the environment.) To do so rendering of virtual backgrounds should be skipped when the display indicates it is transparent.
 
@@ -497,7 +497,7 @@ function onDrawFrame(vrFrame) {
   for (let view in vrFrame.views) {
     let viewport = view.getViewport(vrSession.baseLayer);
     gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
-    if (!vrDisplay.isTransparent) {
+    if (!vrSession.isTransparent) {
       drawBackgroundContent(view, pose);
     }
     drawPrimaryContent(view, pose);
@@ -586,7 +586,6 @@ typedef (WebGLRenderingContext or
 interface VRDevice : EventTarget {
   readonly attribute DOMString deviceName;
   readonly attribute boolean isExternal;
-  readonly attribute boolean isTransparent;
 
   attribute VRSession? activeSession;
 
@@ -613,6 +612,7 @@ interface VRSessionCreateParameters {
 interface VRSession : EventTarget {
   readonly attribute VRDevice device;
   readonly attribute VRSessionCreateParameters createParameters;
+  readonly attribute boolean isTransparent;
 
   attribute double depthNear;
   attribute double depthFar;

--- a/explainer.md
+++ b/explainer.md
@@ -485,9 +485,9 @@ vrSession.addEventListener('resetpose', vrSessionEvent => {
 
 ### Handling Transparent Displays
 
-The majority of current VR devices are opaque and do not enable the user to see their surrounding environment while using it. However some devices, like Microsoft's HoloLens, utilize transparent displays in the service of AR features. While the initial version of the WebVR API does not attempt to provide access to AR-centric features it does communicate whether or no the device display is see-through with the session's `isTransparent` attribute.
+The majority of current VR devices are opaque and do not enable the user to see their surrounding environment while using it. However some devices, like Microsoft's HoloLens, utilize transparent displays in the service of AR features. While the initial version of the WebVR API does not attempt to provide access to AR-centric features it does communicate whether or not the device display is see-through with the session's `isTransparent` attribute.
 
-WebVR content may want to refrain from drawing a background over the full frame in cases where the display is transparent, to allow the virtual content to appear as if it's floating in the real environment. (Note that this version of the WebVR API provides no mechanism for aligning or occluding content againts the environment.) To do so rendering of virtual backgrounds should be skipped when the display indicates it is transparent.
+WebVR content may want to refrain from drawing a background over the full frame in cases where the display is transparent, to allow the virtual content to appear as if it's floating in the real environment. (Note that this version of the WebVR API provides no mechanism for aligning or occluding content againts the environment.) To do so, skip rendering virtual backgrounds when the display indicates it is transparent.
 
 ```js
 function onDrawFrame(vrFrame) {


### PR DESCRIPTION
Addresses #145. Not sure if I like the idea that this resides on the `VRDisplay` (more fingerprinting avenues) but could be useful in cases where a transparent framebuffer needs to be allocated.