### PR TITLE
Fixes pointer events missing from idl in 1.1 spec

### DIFF
--- a/spec/1.1/index.bs
+++ b/spec/1.1/index.bs
@@ -667,6 +667,8 @@ partial interface Window {
   attribute EventHandler onvrdisplayblur;
   attribute EventHandler onvrdisplayfocus;
   attribute EventHandler onvrdisplaypresentchange;
+  attribute EventHandler onvrdisplaypointerrestricted;
+  attribute EventHandler onvrdisplaypointerunrestricted;
 };
 </pre>
 


### PR DESCRIPTION
The descriptions for the vrdisplaypointerresticted and vrdisplaypointerunrestricted events were added to the webvr 1.1 spec in February, but the actual events themselves were missing from the idl.  This commit corrects that mistake.