### PR TITLE
Enable pr-preview

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,7 @@
+{
+    "src_file": "spec/latest/index.bs",
+    "type": "bikeshed",
+    "params": {
+        "force": 1
+    }
+}


### PR DESCRIPTION
Enable pr-preview for the latest WebVR spec that automatically
links both preview and HTML diff from within the pull requests.

https://github.com/tobie/pr-preview/#pr-preview