### PR TITLE
Refactor getDevices into requestDevice

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -44,7 +44,7 @@ The basic steps any WebVR application will go through are:
 
  1. Request a VR device.
  1. If a device is available, application advertises VR functionality to the user.
- 1. Request a VR session from the device in response to a [user-activation event](https://html.spec.whatwg.org/multipage/interaction.html#activation).
+ 1. Request an exclusive VR session from the device in response to a [user-activation event](https://html.spec.whatwg.org/multipage/interaction.html#activation).
  1. Use the session to run a render loop that produces graphical frames to be displayed on the VR device.
  1. Continue producing frames until the user indicates that they wish to exit VR mode.
  1. End the VR session.
@@ -55,7 +55,7 @@ The first thing that any VR-enabled page will want to do is request a `VRDevice`
 
 `navigator.vr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `VRDevice` if one is available. If no `VRDevice` is available, it will resolve to null. The promise will be rejected if an error occurs, such as the the page not having the appropriate permissions to access VR capabilities.
 
-A `VRDevice` represents a physical unit of VR hardware that can present imagery to the user somehow, referred to here as a "VR hardware device". On desktop clients this will usually be a headset peripheral; on mobile clients it may represent the mobile device itself in conjunction with a viewer harness (e.g., Google Cardboard/Daydream or Samsung GearVR). It may also represent devices without stereo-presentation capabilities but with more advanced tracking, such as ARCore/ARKit-compatible devices.
+A `VRDevice` represents a physical unit of VR hardware that can present imagery to the user somehow, referred to here as a "VR hardware device". On desktop clients this will usually be a headset peripheral; on mobile clients it may represent the mobile device itself in conjunction with a viewer harness (e.g., Google Cardboard/Daydream or Samsung Gear VR). It may also represent devices without stereo-presentation capabilities but with more advanced tracking, such as ARCore/ARKit-compatible devices.
 
 ```js
 function checkForVR() {
@@ -72,7 +72,7 @@ function checkForVR() {
 
 Future revisions of the API may add filter criteria to `navigator.vr.requestDevice`.
 
-> **Non-normative Note:** If there are multiple VR devices available, the UA will need to pick which one to return. The UA is allowed to use any criteria it wishes to select which device is returned, including settings UI that allows users to manage device priority. Calling `navigator.vr.requestDevice` should not trigger device selection UI, however, as this would cause many sites to display VR-specific dialogs early in the document lifecycle without and user activation.
+> **Non-normative Note:** If there are multiple VR devices available, the UA will need to pick which one to return. The UA is allowed to use any criteria it wishes to select which device is returned, including settings UI that allows users to manage device priority. Calling `navigator.vr.requestDevice` should not trigger device-selection UI, however, as this would cause many sites to display VR-specific dialogs early in the document lifecycle without and user activation.
 
 It's possible that even if no VR device is available initially, one may become available while the application is running, or that a previously available device becomes unavailable. This will be most common with PC peripherals that can be connected or disconnected at any time. Pages can listen to the `devicechange` event emitted on `navigator.vr` to respond to changes in device availability after the page loads. (VR devices already available when the page loads will not cause a `devicechange` event to be fired.)
 

--- a/explainer.md
+++ b/explainer.md
@@ -40,7 +40,7 @@ VR provides an interesting canvas for artists looking to explore the possibiliti
 
 ## Lifetime of a VR web app
 
-The basic steps any WebVR application will go through are:
+The basic steps most WebVR applications will go through are:
 
  1. Request a VR device.
  1. If a device is available, application advertises VR functionality to the user.
@@ -72,7 +72,7 @@ function checkForVR() {
 
 Future revisions of the API may add filter criteria to `navigator.vr.requestDevice`.
 
-> **Non-normative Note:** If there are multiple VR devices available, the UA will need to pick which one to return. The UA is allowed to use any criteria it wishes to select which device is returned, including settings UI that allows users to manage device priority. Calling `navigator.vr.requestDevice` should not trigger device-selection UI, however, as this would cause many sites to display VR-specific dialogs early in the document lifecycle without and user activation.
+> **Non-normative Note:** If there are multiple VR devices available, the UA will need to pick which one to return. The UA is allowed to use any criteria it wishes to select which device is returned, including settings UI that allows users to manage device priority. Calling `navigator.vr.requestDevice` should not trigger device-selection UI, however, as this would cause many sites to display VR-specific dialogs early in the document lifecycle without user activation.
 
 It's possible that even if no VR device is available initially, one may become available while the application is running, or that a previously available device becomes unavailable. This will be most common with PC peripherals that can be connected or disconnected at any time. Pages can listen to the `devicechange` event emitted on `navigator.vr` to respond to changes in device availability after the page loads. (VR devices already available when the page loads will not cause a `devicechange` event to be fired.)
 

--- a/explainer.md
+++ b/explainer.md
@@ -44,16 +44,16 @@ The basic steps any WebVR application will go through are:
 
  1. Request a VR device.
  1. If a device is available, application advertises VR functionality to the user.
- 1. Request a VR session from the device in response to a user activation event.
+ 1. Request a VR session from the device in response to a [user-activation event](https://html.spec.whatwg.org/multipage/interaction.html#activation).
  1. Use the session to run a render loop that produces graphical frames to be displayed on the VR device.
  1. Continue producing frames until the user indicates that they wish to exit VR mode.
  1. End the VR session.
 
 ### Acquiring a Device
 
-The first thing that any VR-enabled page will want to do is request a `VRDevice` and, if one is available, advertise VR functionality to the user. (For example, by adding a button to the DOM that the user can click to start VR content.)
+The first thing that any VR-enabled page will want to do is request a `VRDevice` and, if one is available, advertise VR functionality to the user. (For example, by adding a button to the page that the user can click to start VR content.)
 
-`navigator.vr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `VRDevice` if one is available. In no `VRDevice` is available it will resolve to null. The promise will be rejected if an error occurs, such as the the page not having the appropriate permissions to access VR capabilities.
+`navigator.vr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to a `VRDevice` if one is available. If no `VRDevice` is available, it will resolve to null. The promise will be rejected if an error occurs, such as the the page not having the appropriate permissions to access VR capabilities.
 
 A `VRDevice` represents a physical unit of VR hardware that can present imagery to the user somehow, referred to here as a "VR hardware device". On desktop clients this will usually be a headset peripheral; on mobile clients it may represent the mobile device itself in conjunction with a viewer harness (e.g., Google Cardboard/Daydream or Samsung GearVR). It may also represent devices without stereo-presentation capabilities but with more advanced tracking, such as ARCore/ARKit-compatible devices.
 
@@ -65,7 +65,7 @@ function checkForVR() {
     }
   }, err => {
     // An error occurred while requesting a VRDevice.
-    console.error('Unable to request a VR device.');
+    console.error('Unable to request a VR device:', err);
   });
 }
 ```
@@ -74,7 +74,7 @@ Future revisions of the API may add filter criteria to `navigator.vr.requestDevi
 
 > **Non-normative Note:** If there are multiple VR devices available, the UA will need to pick which one to return. The UA is allowed to use any criteria it wishes to select which device is returned, including settings UI that allows users to manage device priority. Calling `navigator.vr.requestDevice` should not trigger device selection UI, however, as this would cause many sites to display VR-specific dialogs early in the document lifecycle without and user activation.
 
-It's possible that even if no VR device is available initially one may become available while the application is running, or that a previously available device becomes unavailable. This will be most common with PC peripherals that can be connected at disconnected at any time. To respond to these changes pages can listen to the `devicechange` event on the `navigator.vr` object.
+It's possible that even if no VR device is available initially, one may become available while the application is running, or that a previously available device becomes unavailable. This will be most common with PC peripherals that can be connected or disconnected at any time. Pages can listen to the `devicechange` event emitted on `navigator.vr` to respond to changes in device availability after the page loads. (VR devices already available when the page loads will not cause a `devicechange` event to be fired.)
 
 ```js
 navigator.vr.addEventListener('devicechange', checkForVR);
@@ -82,7 +82,7 @@ navigator.vr.addEventListener('devicechange', checkForVR);
 
 ### Sessions
 
-A `VRDevice` only indicates the availabilty of a VR device. In order to do anything that involves the device's presentation or tracking capabilities, the application will need to request a `VRSession` from the `VRDevice`.
+A `VRDevice` indicates only the availability of a VR device. In order to do anything that involves the device's presentation or tracking capabilities, the application will need to request a `VRSession` from the `VRDevice`.
 
 Sessions can be created with one of two levels of access:
 


### PR DESCRIPTION
Got an initial pull request up, but this is going to take some discussion.

The basic idea is to drop `getDevices` in favor of a `requestDevice` call that can take an optional set of filters. Credit where credit is due, this is basically what @cvan suggested we do [way back in January](https://github.com/w3c/webvr/issues/179#issuecomment-275284599). I felt that we should try and keep the API simpler. Jokes on me, I guess. ;)

Some of the important points:

This follows very closely the pattern already happily established by [WebUSB](https://wicg.github.io/webusb/#enumeration) and [WebBluetooth](https://webbluetoothcg.github.io/web-bluetooth/#device-discovery), right down the the exact function name. That immediately puts my mind at ease a bit, in that it means we feel more at home next to those APIs and means we're able to borrow from the expertise that went into establishing those standards.

Our filters are much more minimal than the other two APIs, however, since there is no perceived benefit and several real downsides to being overly specific in this case. We generally want to encourage developers to take whatever device matches their most coarse requirements (ie: needs to support exclusive presentation, in the future needs to support AR passthrough?). We definitely don't want to allow or encourage "I want a device with at least a screen resolution of X, FoV no smaller than Y, and that supports at least Z simultaneous layers."

There was a question on the most recent call about if we should drop the `VRDevice` object, since we could feasibly just request sessions directly from navigator.vr with this pattern. After stewing on it for a bit I think the answer is "Yes... but there's an issue." Specifically, we still need a way to ensure that WebGL contexts are created with a compatible adapter, and I like the pattern we've established of using the `VRDevice` to indicate what adapter the context needs to be compatible with. (I personally feel it's a hard requirement to allow developers to create compatible contexts prior to the creation of a session.) So in my opinion `VRDevice` stays and simply loses the name string.

That creates a minor complication when it comes to multiple devices connected to a single PC, though. I had this fanciful idea that the `VRDevice` didn't need to represent a physical piece of hardware, and could instead represent all the potential devices that could satisfy the filters, and only when the user attempted to create a `VRSession` would the system throw up a prompt (if necessary) and say "Hey, which of these two headsets do you want to present to?" That breaks the ability to use `VRDevice` as the handle for context compatibility, though, since it's entirely possible those two headsets are connected to different adapters. (It's also just kinda weird when set next to WebUSB and WebBluetooth, both of whom treat their respective devices as a physical piece of hardware.)

So I think a `VRDevice` needs to continue representing just one piece of hardware, which then begs the question of how the poor power user with 4 GPUs chooses between their Rift and Vive when viewing WebVR content.

![](http://i0.kym-cdn.com/photos/images/original/001/093/557/142.gif)

However, I don't think it's a big enough issue for us to try and bend over backwards for. A few things to consider:

- Most users will only have one possible device, either because it's their phone, it's a standalone HMD, or because headsets are expensive and power hungry so it doesn't make much sense to have more than one per machine.
- Even in the case that you do have N devices available, you'll often have a clear indication that the user wants to use a specific device. (If the user is viewing a VR browser in one HMD, they definitely don't want WebVR content to show up on the other.)
- Hardware trends and basic financial factors seem to be favoring standalone and mobile systems long term anyway.
- In the case that it truly is ambiguous the browser could have some internal settings page where the default VR device is set.

Something I don't want to see happen, though, is for pages to pop up a "Which device do you mean?" dialog upon calls to `requestDevice`, because I would expect that to happen early on in most pages lifetime as they try to determine if they should advertise VR features. A UA-driven selection dialog at that step would mean that many pages would immediately ask you to pick a headset upon navigation even though you've made no indication you want to use VR. That's severely user-hostile behavior.

One thing I'd really appreciate is hearing from @grorg if these changes would satisfy Apple's fingerprinting concerns sufficiently. I think we can work out the above issues, but if this change doesn't get us closer to enabling eventual implementation in WebKit then it's something of a moot point.

I need to add a section about how to use the filters, so this PR isn't quite complete even if everyone agrees on the functionality, but I wanted to get the conversation going. As a heads up, I'll be unavailable for the entirety of the week of Oct 2nd, but I hope that the rest of the community group can work towards a resolution in the meantime. This is an important change to finalize soon so that we don't get stuck in spec limbo.